### PR TITLE
Add Tailwind utility to switch visibility between two elements

### DIFF
--- a/modules/tailwind/src/main/scala/io/laminext/tailwind/BaseSyntax.scala
+++ b/modules/tailwind/src/main/scala/io/laminext/tailwind/BaseSyntax.scala
@@ -1,11 +1,11 @@
 package io.laminext.tailwind
 
 import com.raquo.laminar.api.L._
-import io.laminext.tailwind.ops.htmlelement.ReactiveHtmlElementTailwindOps
-import io.laminext.tailwind.ops.svgelement.ReactiveSvgElementTailwindOps
 import com.raquo.laminar.nodes.ReactiveHtmlElement
 import com.raquo.laminar.nodes.ReactiveSvgElement
-import io.laminext.tailwind.modal.Modal
+import io.laminext.tailwind.ops.htmlelement.ReactiveHtmlElementTailwindOps
+import io.laminext.tailwind.ops.signal.SignalOfBooleanTailwindOps
+import io.laminext.tailwind.ops.svgelement.ReactiveSvgElementTailwindOps
 import io.laminext.tailwind.progressbar.ProgressBar
 import io.laminext.tailwind.theme.Theme
 import io.laminext.ui.animation.Animation
@@ -48,5 +48,7 @@ trait BaseSyntax {
   implicit def syntaxReactiveSvgElementTailwind[T <: dom.svg.Element](
     el: ReactiveSvgElement[T]
   ): ReactiveSvgElementTailwindOps[T] = new ReactiveSvgElementTailwindOps[T](el)
+
+  implicit def syntaxSignalOfBooleanTailwind(s: Signal[Boolean]): SignalOfBooleanTailwindOps = new SignalOfBooleanTailwindOps(s)
 
 }

--- a/modules/tailwind/src/main/scala/io/laminext/tailwind/ops/signal/SignalOfBooleanTailwindOps.scala
+++ b/modules/tailwind/src/main/scala/io/laminext/tailwind/ops/signal/SignalOfBooleanTailwindOps.scala
@@ -1,0 +1,15 @@
+package io.laminext.tailwind.ops.signal
+
+import com.raquo.laminar.api.L._
+import io.laminext.syntax.core._
+import io.laminext.syntax.tailwind._
+
+final class SignalOfBooleanTailwindOps(underlying: Signal[Boolean]) {
+
+  @inline def switchVisibility(whenTrue: => HtmlElement, whenFalse: => HtmlElement): Mod[HtmlElement] =
+    nodeSeq(
+      whenTrue.visibleIf(underlying),
+      whenFalse.hiddenIf(underlying)
+    )
+
+}


### PR DESCRIPTION
Small utility to be able to do something like:
```scala
$signalOfBoolean.switchDisplay(
  whenTrue = span("I'm displayed because signalOfBoolean emitted true"),
  whenFalse = span("I'm displayed because signalOfBoolean emitted false")
)
```