### PR TITLE
WebSocket: only send when connected

### DIFF
--- a/modules/websocket/src/main/scala/io/laminext/websocket/WebSocket.scala
+++ b/modules/websocket/src/main/scala/io/laminext/websocket/WebSocket.scala
@@ -121,19 +121,19 @@ class WebSocket[Receive, Send](
   }
 
   private def trySend(): Unit = {
-    if (connectedVar.now()) {
-      maybeWS.foreach { ws =>
-        sendBuffer.foreach { message =>
-          sender(ws, message)
-        }
-        sendBuffer.clear()
-      }
-    } else {
+    val connectedWS = maybeWS.filter(_.readyState == 1 /* OPEN */ )
+    if (js.isUndefined(connectedWS)) {
       if (!bufferWhenDisconnected) {
         sendBuffer.clear()
       } else if (sendBuffer.size > bufferSize) {
         sendBuffer.drop(sendBuffer.size - bufferSize)
       }
+    }
+    connectedWS.foreach { ws =>
+      sendBuffer.foreach { message =>
+        sender(ws, message)
+      }
+      sendBuffer.clear()
     }
   }
 

--- a/modules/websocket/src/main/scala/io/laminext/websocket/WebSocket.scala
+++ b/modules/websocket/src/main/scala/io/laminext/websocket/WebSocket.scala
@@ -121,18 +121,19 @@ class WebSocket[Receive, Send](
   }
 
   private def trySend(): Unit = {
-    if (js.isUndefined(maybeWS)) {
+    if (connectedVar.now()) {
+      maybeWS.foreach { ws =>
+        sendBuffer.foreach { message =>
+          sender(ws, message)
+        }
+        sendBuffer.clear()
+      }
+    } else {
       if (!bufferWhenDisconnected) {
         sendBuffer.clear()
       } else if (sendBuffer.size > bufferSize) {
         sendBuffer.drop(sendBuffer.size - bufferSize)
       }
-    }
-    maybeWS.foreach { ws =>
-      sendBuffer.foreach { message =>
-        sender(ws, message)
-      }
-      sendBuffer.clear()
     }
   }
 


### PR DESCRIPTION
Testing if `maybeWS` is undefined is not enough as the connection may be in `CONNECTING` state.

Example error:
```
ObserverError: InvalidStateError: Failed to execute 'send' on 'WebSocket': Still in CONNECTING state.
com.raquo.airstream.core.Observer$$anon$8.onNext(http://localhost:8080/main.js:33536:37)
{anonymous}()(http://localhost:8080/main.js:10288:12)
scala.scalajs.runtime.AnonFunction1.apply(http://localhost:8080/main.js:31122:43)
{anonymous}()(http://localhost:8080/main.js:17685:61)
scala.scalajs.runtime.AnonFunction1.apply(http://localhost:8080/main.js:31122:43)
{anonymous}()(http://localhost:8080/main.js:17690:16)
scala.scalajs.runtime.AnonFunction1.apply(http://localhost:8080/main.js:31122:43)
com.raquo.airstream.ownership.DynamicSubscription$.subscribeCallback(http://localhost:8080/main.js:1857:16)
scala.scalajs.runtime.AnonFunction1.apply(http://localhost:8080/main.js:31122:43)
com.raquo.airstream.ownership.DynamicSubscription.onActivate(http://localhost:8080/main.js:1809:170)
```